### PR TITLE
Add permissions check on the change profile picture WP JSON api.

### DIFF
--- a/metronet-profile-picture.php
+++ b/metronet-profile-picture.php
@@ -992,7 +992,9 @@ class Metronet_Profile_Picture {
             array(
                 'methods'             => 'POST',
                 'callback'            => array( $this, 'rest_api_change_profile_image' ),
-                'permission_callback' => '__return_true',
+                'permission_callback' => function( $request ){
+                    return current_user_can( 'manage_options' );
+                }
             )
         );
         register_rest_route(


### PR DESCRIPTION
This endpoint does not seem to be used by the plugin at the moment, it seems to have been added in preparation for something else.

I have simply added a permission check in the REST API definition so that this action can only be performed by an admin.
